### PR TITLE
Fixes #29: Check for invalid opcodes/values

### DIFF
--- a/src/negative/invalid_addr_mode.asm
+++ b/src/negative/invalid_addr_mode.asm
@@ -1,0 +1,11 @@
+	.inesprg 1
+	.ineschr 0
+	.inesmir 1
+	.inesmap 0
+
+	.org $8000
+	.bank 0
+
+Start:
+	ldx $1000,Y
+	rts

--- a/src/negative/invalid_immediate.asm
+++ b/src/negative/invalid_immediate.asm
@@ -1,0 +1,11 @@
+	.inesprg 1
+	.ineschr 0
+	.inesmir 1
+	.inesmap 0
+
+	.org $8000
+	.bank 0
+
+Start:
+	lda #$0100
+	rts

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -1,23 +1,35 @@
 #include "opcodes.h"
 
-unsigned char opcode_set_addr_mode(unsigned char group, unsigned char base, unsigned char addr_mode) {
+int opcode_set_addr_mode(unsigned char group, unsigned char base, unsigned char addr_mode,
+                         unsigned char *out) {
+  unsigned char encoded = base;
+
   switch (group) {
     case opcode_CC01:
-      base = opcode_CC01_set_addr_mode(base, addr_mode);
+      if (!opcode_CC01_set_addr_mode(base, addr_mode, &encoded)) {
+        return 0;
+      }
       break;
     case opcode_CC10:
-      base = opcode_CC10_set_addr_mode(base, addr_mode);
+      if (!opcode_CC10_set_addr_mode(base, addr_mode, &encoded)) {
+        return 0;
+      }
       break;
     case opcode_CC00:
-      base = opcode_CC00_set_addr_mode(base, addr_mode);
+      if (!opcode_CC00_set_addr_mode(base, addr_mode, &encoded)) {
+        return 0;
+      }
       break;
     case opcode_BRANCH:
     case opcode_IS:
     case opcode_REM:
     default:
+      encoded = base;
       break;
   }
-  return base;
+
+  *out = encoded;
+  return 1;
 }
 
 unsigned char opcode_bbb_set_addr_mode(unsigned char base, unsigned char addr_mode) {
@@ -25,7 +37,7 @@ unsigned char opcode_bbb_set_addr_mode(unsigned char base, unsigned char addr_mo
   return base | (addr_mode << 2);
 }
 
-unsigned char opcode_CC01_set_addr_mode(unsigned char base, unsigned char addr_mode) {
+int opcode_CC01_set_addr_mode(unsigned char base, unsigned char addr_mode, unsigned char *out) {
   /*
   000 (zero page,X)
   001 zero page
@@ -36,10 +48,15 @@ unsigned char opcode_CC01_set_addr_mode(unsigned char base, unsigned char addr_m
   110 absolute,Y
   111 absolute,X
    */
-  return opcode_bbb_set_addr_mode(base, addr_mode);;
+  if (addr_mode == mode_ACC) {
+    return 0;
+  }
+
+  *out = opcode_bbb_set_addr_mode(base, addr_mode);
+  return 1;
 }
 
-unsigned char opcode_CC10_set_addr_mode(unsigned char base, unsigned char addr_mode) {
+int opcode_CC10_set_addr_mode(unsigned char base, unsigned char addr_mode, unsigned char *out) {
   /*
   000 #immediate
   001 zero page
@@ -77,24 +94,47 @@ unsigned char opcode_CC10_set_addr_mode(unsigned char base, unsigned char addr_m
     case mode_IND_Y:
     case mode_ABS_Y:
     default:
-      // throw exception
-      break;
+      return 0;
   }
-  return opcode_bbb_set_addr_mode(base, cc10_addr_mode);
+
+  *out = opcode_bbb_set_addr_mode(base, cc10_addr_mode);
+  return 1;
 }
 
-unsigned char opcode_CC00_set_addr_mode(unsigned char base, unsigned char addr_mode) {
-  // Check if it's jmp
-  // TODO: Check when 0x6c should be used rather than 0x4c
-  //
-  // if (base == 0x40) {
-  //   if (addr_mode == mode_ABS) {
-  //     base = 0x60;
-  //   }
-  // }
+static int cc00_addr_mode_valid(unsigned char base, unsigned char addr_mode) {
+  unsigned char aaa = (base >> 5) & 0x7;
 
-  // Apart from jmp, it's same as CC10 addresses
-  return opcode_CC10_set_addr_mode(base, addr_mode);
+  switch (aaa) {
+    case 1: /* BIT */
+      return addr_mode == mode_ZERO || addr_mode == mode_ABS;
+
+    case 2: /* JMP */
+      return addr_mode == mode_ABS;
+
+    case 4: /* STY */
+      return addr_mode == mode_ZERO || addr_mode == mode_ABS ||
+             addr_mode == mode_ZERO_X || addr_mode == mode_ABS_X;
+
+    case 5: /* LDY */
+      return addr_mode == mode_IMM || addr_mode == mode_ZERO ||
+             addr_mode == mode_ZERO_X || addr_mode == mode_ABS ||
+             addr_mode == mode_ABS_X;
+
+    case 6: /* CPY */
+    case 7: /* CPX */
+      return addr_mode == mode_IMM || addr_mode == mode_ABS;
+
+    default:
+      return 0;
+  }
+}
+
+int opcode_CC00_set_addr_mode(unsigned char base, unsigned char addr_mode, unsigned char *out) {
+  if (!cc00_addr_mode_valid(base, addr_mode)) {
+    return 0;
+  }
+
+  return opcode_CC10_set_addr_mode(base, addr_mode, out);
 }
 
 int branch_relative(unsigned short from, unsigned short to, char *out) {

--- a/src/opcodes.h
+++ b/src/opcodes.h
@@ -32,10 +32,11 @@
 #define mode_ABS_X  0x07
 #define mode_ACC    0x08
 
-unsigned char opcode_set_addr_mode(unsigned char group, unsigned char base, unsigned char addr_mode);
-unsigned char opcode_CC01_set_addr_mode(unsigned char base, unsigned char addr_mode);
-unsigned char opcode_CC10_set_addr_mode(unsigned char base, unsigned char addr_mode);
-unsigned char opcode_CC00_set_addr_mode(unsigned char base, unsigned char addr_mode);
+int opcode_set_addr_mode(unsigned char group, unsigned char base, unsigned char addr_mode,
+                         unsigned char *out);
+int opcode_CC01_set_addr_mode(unsigned char base, unsigned char addr_mode, unsigned char *out);
+int opcode_CC10_set_addr_mode(unsigned char base, unsigned char addr_mode, unsigned char *out);
+int opcode_CC00_set_addr_mode(unsigned char base, unsigned char addr_mode, unsigned char *out);
 
 int branch_relative(unsigned short from, unsigned short to, char *out);
 

--- a/src/parser.y
+++ b/src/parser.y
@@ -24,6 +24,14 @@ void logsymbol(symbol s);
 void logforwardsymbol(const char *s);
 void yyerror(const char *s);
 
+#define ENCODE_ADDR_MODE(op, mode) \
+  do { \
+    if (!opcode_set_addr_mode((op).type, (op).base, (mode), &(op).base)) { \
+      yyerror("Invalid addressing mode for instruction"); \
+      YYABORT; \
+    } \
+  } while (0)
+
 extern BankTable bankTable;
 extern InesHeader inesHeader;
 
@@ -189,7 +197,7 @@ instruction:
     localSymbols.add($1, labelOffset);
   }
   | T_INSTR byte_imm {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_IMM);
+    ENCODE_ADDR_MODE($1, mode_IMM);
 
     currentBank->addByte($1.base);
     currentBank->addByte($2);
@@ -198,10 +206,14 @@ instruction:
     loginstr($2);
   }
   | T_INSTR word_imm {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_IMM);
+    if ($2 > 0xFF) {
+      yyerror("Immediate value must be a byte");
+      YYABORT;
+    }
+    ENCODE_ADDR_MODE($1, mode_IMM);
 
     currentBank->addByte($1.base);
-    currentBank->addWord($2);
+    currentBank->addByte($2);
 
     logoptype("IMM", $1.base);
     loginstr($2);
@@ -214,7 +226,7 @@ instruction:
       logoptype("REL", $1.base);
       loginstr($2);
     } else {
-      $1.base = opcode_set_addr_mode($1.type, $1.base, mode_ZERO);
+      ENCODE_ADDR_MODE($1, mode_ZERO);
       currentBank->addByte($1.base);
       currentBank->addByte($2);
 
@@ -243,7 +255,7 @@ instruction:
       loginstr($2);
       loginstr(relative);
     } else {
-      $1.base = opcode_set_addr_mode($1.type, $1.base, mode_ABS);
+      ENCODE_ADDR_MODE($1, mode_ABS);
 
       currentBank->addByte($1.base);
       currentBank->addWord($2);
@@ -253,7 +265,7 @@ instruction:
     }
   }
   | T_INSTR byte T_COMMA T_X_REGISTER {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_ZERO_X);
+    ENCODE_ADDR_MODE($1, mode_ZERO_X);
 
     currentBank->addByte($1.base);
     currentBank->addByte($2);
@@ -262,7 +274,7 @@ instruction:
     loginstr($2);
   }
   | T_INSTR word T_COMMA T_X_REGISTER {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_ABS_X);
+    ENCODE_ADDR_MODE($1, mode_ABS_X);
 
     currentBank->addByte($1.base);
     currentBank->addWord($2);
@@ -271,7 +283,7 @@ instruction:
     loginstr($2);
   }
   | T_INSTR word T_COMMA T_Y_REGISTER {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_ABS_Y);
+    ENCODE_ADDR_MODE($1, mode_ABS_Y);
 
     currentBank->addByte($1.base);
     currentBank->addWord($2);
@@ -280,7 +292,7 @@ instruction:
     loginstr($2);
   }
   | T_INSTR T_OPEN_PAREN zp_byte T_CLOSE_PAREN T_COMMA T_Y_REGISTER {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_IND_Y);
+    ENCODE_ADDR_MODE($1, mode_IND_Y);
 
     currentBank->addByte($1.base);
     currentBank->addByte($3);
@@ -289,7 +301,7 @@ instruction:
     loginstr($3);
   }
   | T_INSTR T_OPEN_PAREN zp_byte T_COMMA T_X_REGISTER T_CLOSE_PAREN {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_IND_X);
+    ENCODE_ADDR_MODE($1, mode_IND_X);
 
     currentBank->addByte($1.base);
     currentBank->addByte($3);
@@ -298,7 +310,7 @@ instruction:
     loginstr($3);
   }
   | T_INSTR T_ACCUMULATOR {
-    $1.base = opcode_set_addr_mode($1.type, $1.base, mode_ACC);
+    ENCODE_ADDR_MODE($1, mode_ACC);
 
     currentBank->addByte($1.base);
 
@@ -604,5 +616,5 @@ void logforwardsymbol(const char *s) {
 }
 
 void yyerror(const char *s) {
-  cerr << "Error on line (" << dec << line_num << "): " << s << endl;
+  cerr << "Error on line (" << line_num << "): " << s << endl;
 }

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -177,3 +177,11 @@ TEST_CASE("word expressions support add/subtract with parentheses",
   std::remove(asm_path.c_str());
   std::remove(output_path.c_str());
 }
+
+TEST_CASE("invalid addressing mode is rejected", "[integration][negative]") {
+  expect_assembler_failure({"-o", ".yana_test_addr_mode.nes", "negative/invalid_addr_mode.asm"});
+}
+
+TEST_CASE("immediate value out of range is rejected", "[integration][negative]") {
+  expect_assembler_failure({"-o", ".yana_test_immediate.nes", "negative/invalid_immediate.asm"});
+}


### PR DESCRIPTION
## Summary
- Reject invalid addressing mode combinations for CC01/CC10/CC00 instruction groups instead of silently emitting wrong opcode bytes
- Validate CC00 instructions per mnemonic (BIT, JMP, STY, LDY, CPY, CPX) and CC01 accumulator misuse
- Reject immediate operands larger than a byte (`#$0100` and similar)
- Route `yyerror` to stderr with non-zero exit via `YYABORT` (consistent with #72 error pattern)

## Test plan
- [x] `ctest --test-dir build --output-on-failure` — 13/13 tests pass
- [x] New negative fixtures: `negative/invalid_addr_mode.asm`, `negative/invalid_immediate.asm`
- [x] Existing NESASM reference assembly tests unchanged

Fixes #29