### PR TITLE
Fixes #81: Add byte expression support for 8-bit operands

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -23,6 +23,7 @@ void loginstr(const char *s);
 void logsymbol(symbol s);
 void logforwardsymbol(const char *s);
 void yyerror(const char *s);
+unsigned char byte_expr_value(unsigned short value, const char *rangeError);
 
 #define ENCODE_ADDR_MODE(op, mode) \
   do { \
@@ -92,6 +93,14 @@ unsigned short internalRS;
 %type <word> word_value
 %type <word> word_primary_imm
 %type <word> word_value_imm
+%type <word> byte_expr
+%type <word> byte_primary
+%type <word> byte_value
+%type <word> byte_value_expr
+%type <word> byte_expr_imm
+%type <word> byte_primary_imm
+%type <word> byte_value_imm
+%type <word> byte_value_expr_imm
 %type <byte> byte
 %type <byte> byte_imm
 %type <byte> zp_byte
@@ -416,11 +425,7 @@ T_FILE:
   ;
 
 byte:
-  T_BYTE
-  | T_SYMBOL_BYTE {
-    logsymbol($1);
-    $$ = $1.address;
-  }
+  byte_expr { $$ = byte_expr_value($1, "Operand out of range"); }
   | T_HIGH T_OPEN_PAREN T_SYMBOL T_CLOSE_PAREN {
     $$ = ($3.address >> 8);
   }
@@ -443,8 +448,36 @@ byte:
   }
   ;
 
+byte_expr:
+  byte_expr T_PLUS byte_value { $$ = $1 + $3; }
+  | byte_expr T_MINUS byte_value { $$ = $1 - $3; }
+  | byte_primary
+  ;
+
+byte_primary:
+  T_BYTE { $$ = $1; }
+  | T_SYMBOL_BYTE {
+    logsymbol($1);
+    $$ = $1.address;
+  }
+  | T_OPEN_PAREN byte_value_expr T_CLOSE_PAREN { $$ = $2; }
+  ;
+
+byte_value:
+  byte_primary
+  ;
+
+byte_value_expr:
+  byte_value_expr T_PLUS byte_value { $$ = $1 + $3; }
+  | byte_value_expr T_MINUS byte_value { $$ = $1 - $3; }
+  | byte_value
+  ;
+
 zp_byte:
   byte
+  | word_expr {
+    $$ = byte_expr_value($1, "Indirect addressing requires a zero page operand");
+  }
   | T_SYMBOL {
     logsymbol($1);
     if ($1.address > 0xff) {
@@ -461,11 +494,7 @@ zp_byte:
   ;
 
 byte_imm:
-  T_BYTE_IMM
-  | T_SYMBOL_BYTE_IMM {
-    logsymbol($1);
-    $$ = $1.address;
-  }
+  byte_expr_imm { $$ = byte_expr_value($1, "Operand out of range"); }
   | T_HIGH_IMM T_OPEN_PAREN T_SYMBOL T_CLOSE_PAREN {
     $$ = ($3.address >> 8);
   }
@@ -486,6 +515,36 @@ byte_imm:
     logforwardsymbol($3);
     $$ = 0xff;
   }
+  ;
+
+byte_expr_imm:
+  byte_expr_imm T_PLUS byte_value_imm { $$ = $1 + $3; }
+  | byte_expr_imm T_MINUS byte_value_imm { $$ = $1 - $3; }
+  | byte_primary_imm
+  ;
+
+byte_primary_imm:
+  T_BYTE_IMM { $$ = $1; }
+  | T_BYTE { $$ = $1; }
+  | T_SYMBOL_BYTE_IMM {
+    logsymbol($1);
+    $$ = $1.address;
+  }
+  | T_SYMBOL_BYTE {
+    logsymbol($1);
+    $$ = $1.address;
+  }
+  | T_OPEN_PAREN byte_value_expr_imm T_CLOSE_PAREN { $$ = $2; }
+  ;
+
+byte_value_imm:
+  byte_primary_imm
+  ;
+
+byte_value_expr_imm:
+  byte_value_expr_imm T_PLUS byte_value_imm { $$ = $1 + $3; }
+  | byte_value_expr_imm T_MINUS byte_value_imm { $$ = $1 - $3; }
+  | byte_value_imm
   ;
 
 word:
@@ -617,4 +676,11 @@ void logforwardsymbol(const char *s) {
 
 void yyerror(const char *s) {
   cerr << "Error on line (" << line_num << "): " << s << endl;
+}
+
+unsigned char byte_expr_value(unsigned short value, const char *rangeError) {
+  if (value > 0xff) {
+    throw runtime_error(rangeError);
+  }
+  return value & 0xff;
 }

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -185,3 +185,69 @@ TEST_CASE("invalid addressing mode is rejected", "[integration][negative]") {
 TEST_CASE("immediate value out of range is rejected", "[integration][negative]") {
   expect_assembler_failure({"-o", ".yana_test_immediate.nes", "negative/invalid_immediate.asm"});
 }
+
+TEST_CASE("byte expressions support add/subtract and reject out of range",
+          "[integration][assembly][negative]") {
+  const std::string asm_path = std::string(YANA_DATA_DIR) + "/.yana_test_byte_expr.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_byte_expr.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n\n";
+    output << ".db ($10 + 1), ($20 - 1)\n";
+    output << "LDA #$10 + 1\n";
+    output << "LDA #$ff - 1\n";
+    output << "LDA ($20 + 2), Y\n";
+    output << "LDA ($20 + 3, X)\n";
+  }
+
+  const ProcessResult result =
+      run_yana({"-o", ".yana_test_byte_expr.nes", ".yana_test_byte_expr.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 16 + 10);
+  const std::vector<unsigned char> actual(rom.begin() + 16, rom.begin() + 16 + 10);
+  const std::vector<unsigned char> expected = {
+      0x11, 0x1f,  // .db ($10 + 1), ($20 - 1)
+      0xa9, 0x11,  // LDA #($10 + 1)
+      0xa9, 0xfe,  // LDA #($ff - 1)
+      0xb1, 0x22,  // LDA ($20 + 2), Y
+      0xa1, 0x23,  // LDA ($20 + 3, X)
+  };
+  REQUIRE(actual == expected);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}
+
+TEST_CASE("byte expression out of range is rejected", "[integration][negative]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_byte_expr_range.asm";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n\n";
+    output << "LDA #$ff + 1\n";
+  }
+
+  const ProcessResult result = run_yana(
+      {"-o", ".yana_test_byte_expr_range.nes", ".yana_test_byte_expr_range.asm"});
+  REQUIRE(result.exit_code != 0);
+
+  std::remove(asm_path.c_str());
+  std::remove((std::string(YANA_DATA_DIR) + "/.yana_test_byte_expr_range.nes").c_str());
+}


### PR DESCRIPTION
## Summary
- Add byte expression parsing for `+` and `-` operations using 8-bit operands in parser rules.
- Wire expression handling into `byte`, `byte_imm`, and `zp_byte` parsing paths.
- Validate byte-expression results and error when values are out of the `0x00..0xFF` range.
- Add Catch2 integration tests that generate temporary asm files under `src/` for positive and out-of-range byte-expression scenarios.

## Dependency
- This PR depends on #95 (`issue-80-word-expressions`) because it builds on the expression infrastructure introduced there.

## Test Plan
- [x] `cmake --build build`
- [x] `ctest --test-dir build --output-on-failure`

Fixes #81