### PR TITLE
Fixes #82: Support forward symbols in data expressions

### DIFF
--- a/src/bank.cpp
+++ b/src/bank.cpp
@@ -127,6 +127,9 @@ bool BankTable::updateForwardSymbols(SymbolTable &symbolTable) {
           case WORD:
             bank->addWord(sym.address);
             break;
+          case WORD_EXPR:
+            bank->addWord(sym.address + forward.exprOffset);
+            break;
 
           case BYTE_HIGH:
             bank->addByte(sym.address >> 8);
@@ -135,6 +138,16 @@ bool BankTable::updateForwardSymbols(SymbolTable &symbolTable) {
           case BYTE_LOW:
             bank->addByte(sym.address & 0xff);
             break;
+          case BYTE_EXPR: {
+            int byteValue = static_cast<int>(sym.address) + forward.exprOffset;
+            if (byteValue < 0 || byteValue > 0xff) {
+              cerr << "error: Operand out of range!" << endl;
+              cerr << "Referenced [" << forward.name << "] at line (" << forward.lineNum << ")." << endl;
+              return false;
+            }
+            bank->addByte(static_cast<unsigned char>(byteValue));
+            break;
+          }
 
           case BYTE_REL: {
             char relative;

--- a/src/parser.y
+++ b/src/parser.y
@@ -84,6 +84,7 @@ unsigned short internalRS;
 %token <c_str> T_STRING_LITERAL
 
 %type <word> word
+%type <word> word_data
 %type <word> word_imm
 %type <word> word_expr
 %type <word> word_expr_imm
@@ -101,6 +102,7 @@ unsigned short internalRS;
 %type <word> byte_primary_imm
 %type <word> byte_value_imm
 %type <word> byte_value_expr_imm
+%type <word> byte_data
 %type <byte> byte
 %type <byte> byte_imm
 %type <byte> zp_byte
@@ -386,10 +388,10 @@ T_DATA:
   ;
 
 T_WORDS:
-  T_WORDS word {
+  T_WORDS word_data {
     currentBank->addWord($2);
   }
-  | T_WORDS T_COMMA word {
+  | T_WORDS T_COMMA word_data {
     currentBank->addWord($3);
   }
   | T_WORDS byte {
@@ -398,7 +400,7 @@ T_WORDS:
   | T_WORDS T_COMMA byte {
     currentBank->addWord($3);
   }
-  | word {
+  | word_data {
     currentBank->addWord($1);
   }
   | byte {
@@ -407,13 +409,13 @@ T_WORDS:
   ;
 
 T_BYTES:
-  T_BYTES byte {
+  T_BYTES byte_data {
     currentBank->addByte($2);
   }
-  | T_BYTES T_COMMA byte {
+  | T_BYTES T_COMMA byte_data {
     currentBank->addByte($3);
   }
-  | byte {
+  | byte_data {
     currentBank->addByte($1);
   }
   ;
@@ -426,6 +428,44 @@ T_FILE:
 
 byte:
   byte_expr { $$ = byte_expr_value($1, "Operand out of range"); }
+  ;
+
+byte_data:
+  byte { $$ = $1; }
+  | T_FORWARD_SYMBOL {
+    localSymbols.addForwardExprByte($1, currentBankNo, currentBank->currentOffset(), line_num, 0);
+    logforwardsymbol($1);
+    $$ = 0xff;
+  }
+  | T_FORWARD_SYMBOL T_PLUS byte_value {
+    localSymbols.addForwardExprByte($1, currentBankNo, currentBank->currentOffset(), line_num, static_cast<short>($3));
+    logforwardsymbol($1);
+    $$ = 0xff;
+  }
+  | T_FORWARD_SYMBOL T_MINUS byte_value {
+    localSymbols.addForwardExprByte($1, currentBankNo, currentBank->currentOffset(), line_num, -static_cast<short>($3));
+    logforwardsymbol($1);
+    $$ = 0xff;
+  }
+  | byte_value T_PLUS T_FORWARD_SYMBOL {
+    localSymbols.addForwardExprByte($3, currentBankNo, currentBank->currentOffset(), line_num, static_cast<short>($1));
+    logforwardsymbol($3);
+    $$ = 0xff;
+  }
+  ;
+
+byte_expr:
+  byte_expr T_PLUS byte_value { $$ = $1 + $3; }
+  | byte_expr T_MINUS byte_value { $$ = $1 - $3; }
+  | byte_primary
+  ;
+
+byte_primary:
+  T_BYTE { $$ = $1; }
+  | T_SYMBOL_BYTE {
+    logsymbol($1);
+    $$ = $1.address;
+  }
   | T_HIGH T_OPEN_PAREN T_SYMBOL T_CLOSE_PAREN {
     $$ = ($3.address >> 8);
   }
@@ -445,20 +485,6 @@ byte:
     localSymbols.addForwardLow($3, currentBankNo, currentBank->currentOffset() + 1, line_num);
     logforwardsymbol($3);
     $$ = 0xff;
-  }
-  ;
-
-byte_expr:
-  byte_expr T_PLUS byte_value { $$ = $1 + $3; }
-  | byte_expr T_MINUS byte_value { $$ = $1 - $3; }
-  | byte_primary
-  ;
-
-byte_primary:
-  T_BYTE { $$ = $1; }
-  | T_SYMBOL_BYTE {
-    logsymbol($1);
-    $$ = $1.address;
   }
   | T_OPEN_PAREN byte_value_expr T_CLOSE_PAREN { $$ = $2; }
   ;
@@ -495,6 +521,25 @@ zp_byte:
 
 byte_imm:
   byte_expr_imm { $$ = byte_expr_value($1, "Operand out of range"); }
+  ;
+
+byte_expr_imm:
+  byte_expr_imm T_PLUS byte_value_imm { $$ = $1 + $3; }
+  | byte_expr_imm T_MINUS byte_value_imm { $$ = $1 - $3; }
+  | byte_primary_imm
+  ;
+
+byte_primary_imm:
+  T_BYTE_IMM { $$ = $1; }
+  | T_BYTE { $$ = $1; }
+  | T_SYMBOL_BYTE_IMM {
+    logsymbol($1);
+    $$ = $1.address;
+  }
+  | T_SYMBOL_BYTE {
+    logsymbol($1);
+    $$ = $1.address;
+  }
   | T_HIGH_IMM T_OPEN_PAREN T_SYMBOL T_CLOSE_PAREN {
     $$ = ($3.address >> 8);
   }
@@ -514,25 +559,6 @@ byte_imm:
     localSymbols.addForwardLow($3, currentBankNo, currentBank->currentOffset() + 1, line_num);
     logforwardsymbol($3);
     $$ = 0xff;
-  }
-  ;
-
-byte_expr_imm:
-  byte_expr_imm T_PLUS byte_value_imm { $$ = $1 + $3; }
-  | byte_expr_imm T_MINUS byte_value_imm { $$ = $1 - $3; }
-  | byte_primary_imm
-  ;
-
-byte_primary_imm:
-  T_BYTE_IMM { $$ = $1; }
-  | T_BYTE { $$ = $1; }
-  | T_SYMBOL_BYTE_IMM {
-    logsymbol($1);
-    $$ = $1.address;
-  }
-  | T_SYMBOL_BYTE {
-    logsymbol($1);
-    $$ = $1.address;
   }
   | T_OPEN_PAREN byte_value_expr_imm T_CLOSE_PAREN { $$ = $2; }
   ;
@@ -559,6 +585,34 @@ word:
   | T_SYMBOL {
     logsymbol($1);
     $$ = $1.address;
+  }
+  ;
+
+word_data:
+  word_expr { $$ = $1; }
+  | T_SYMBOL {
+    logsymbol($1);
+    $$ = $1.address;
+  }
+  | T_FORWARD_SYMBOL {
+    localSymbols.addForwardExprWord($1, currentBankNo, currentBank->currentOffset(), line_num, 0);
+    logforwardsymbol($1);
+    $$ = 0xffff;
+  }
+  | T_FORWARD_SYMBOL T_PLUS word_value {
+    localSymbols.addForwardExprWord($1, currentBankNo, currentBank->currentOffset(), line_num, static_cast<short>($3));
+    logforwardsymbol($1);
+    $$ = 0xffff;
+  }
+  | T_FORWARD_SYMBOL T_MINUS word_value {
+    localSymbols.addForwardExprWord($1, currentBankNo, currentBank->currentOffset(), line_num, -static_cast<short>($3));
+    logforwardsymbol($1);
+    $$ = 0xffff;
+  }
+  | word_value T_PLUS T_FORWARD_SYMBOL {
+    localSymbols.addForwardExprWord($3, currentBankNo, currentBank->currentOffset(), line_num, static_cast<short>($1));
+    logforwardsymbol($3);
+    $$ = 0xffff;
   }
   ;
 

--- a/src/symbol.cpp
+++ b/src/symbol.cpp
@@ -18,19 +18,28 @@ void SymbolTable::addByte(std::string name, unsigned short address) {
   symbol_map[name] = s;
 };
 
-void SymbolTable::addForward(std::string name, unsigned char bankNo, unsigned short address, int lineNum, symbol_type type) {
+void SymbolTable::addForward(std::string name, unsigned char bankNo, unsigned short address, int lineNum, symbol_type type, short exprOffset) {
   forward_symbol s;
   s.name = name;
   s.bankNo = bankNo;
   s.address = address;
   s.lineNum = lineNum;
   s.type = type;
+  s.exprOffset = exprOffset;
 
   forward_symbols.push_back(s);
 }
 
 void SymbolTable::addForward(std::string name, unsigned char bankNo, unsigned short address, int lineNum) {
   addForward(name, bankNo, address, lineNum, WORD);
+}
+
+void SymbolTable::addForwardExprWord(std::string name, unsigned char bankNo, unsigned short address, int lineNum, short exprOffset) {
+  addForward(name, bankNo, address, lineNum, WORD_EXPR, exprOffset);
+}
+
+void SymbolTable::addForwardExprByte(std::string name, unsigned char bankNo, unsigned short address, int lineNum, short exprOffset) {
+  addForward(name, bankNo, address, lineNum, BYTE_EXPR, exprOffset);
 }
 
 void SymbolTable::addForwardHigh(std::string name, unsigned char bankNo, unsigned short address, int lineNum) {

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -12,7 +12,7 @@ struct less_string {
   }
 };
 
-enum symbol_type{WORD, BYTE_HIGH, BYTE_LOW, BYTE_REL};
+enum symbol_type{WORD, BYTE_HIGH, BYTE_LOW, BYTE_REL, WORD_EXPR, BYTE_EXPR};
 
 struct symbol {
   const char *name;
@@ -26,6 +26,7 @@ struct forward_symbol {
   unsigned short address;
   int lineNum;
   symbol_type type;
+  short exprOffset;
 };
 
 class SymbolTable {
@@ -34,6 +35,8 @@ public:
   void add(std::string name, unsigned short address);
   void addByte(std::string name, unsigned short address);
   void addForward(std::string name, unsigned char bankNo, unsigned short address, int lineNum);
+  void addForwardExprWord(std::string name, unsigned char bankNo, unsigned short address, int lineNum, short exprOffset);
+  void addForwardExprByte(std::string name, unsigned char bankNo, unsigned short address, int lineNum, short exprOffset);
   void addForwardHigh(std::string name, unsigned char bankNo, unsigned short address, int lineNum);
   void addForwardLow(std::string name, unsigned char bankNo, unsigned short address, int lineNum);
   void addForwardRel(std::string name, unsigned char bankNo, unsigned short address, int lineNum);
@@ -43,7 +46,7 @@ public:
   bool setForwardRel(int lineNum);
 
 private:
-  void addForward(std::string name, unsigned char bankNo, unsigned short address, int lineNum, symbol_type type);
+  void addForward(std::string name, unsigned char bankNo, unsigned short address, int lineNum, symbol_type type, short exprOffset = 0);
 
   std::map<std::string, symbol, less_string> symbol_map;
   std::vector<forward_symbol> forward_symbols;

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -251,3 +251,44 @@ TEST_CASE("byte expression out of range is rejected", "[integration][negative]")
   std::remove(asm_path.c_str());
   std::remove((std::string(YANA_DATA_DIR) + "/.yana_test_byte_expr_range.nes").c_str());
 }
+
+TEST_CASE("forward symbols work inside word/byte data expressions",
+          "[integration][assembly]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_forward_expr_data.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_forward_expr_data.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $0000\n\n";
+    output << ".dw ForwardLabel + 1\n";
+    output << ".db ForwardLabel, ForwardLabel + 2\n";
+    output << "ForwardLabel:\n";
+    output << ".db $aa\n";
+  }
+
+  const ProcessResult result = run_yana(
+      {"-o", ".yana_test_forward_expr_data.nes", ".yana_test_forward_expr_data.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 16 + 5);
+  const std::vector<unsigned char> actual(rom.begin() + 16, rom.begin() + 16 + 5);
+  const std::vector<unsigned char> expected = {
+      0x05, 0x00,  // .dw ForwardLabel + 1
+      0x04,        // .db ForwardLabel
+      0x06,        // .db ForwardLabel + 2
+      0xaa,        // ForwardLabel
+  };
+  REQUIRE(actual == expected);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}


### PR DESCRIPTION
## Summary
- extend forward symbol records to carry expression offsets for second-pass patching
- patch `.dw`/`.db` forward expression values in `BankTable::updateForwardSymbols` with byte-range validation
- allow forward symbols in data expression grammar and add a Catch2 integration test for `.dw`/`.db` forward expressions

## Test plan
- [x] `cmake --build build`
- [x] `ctest --test-dir build --output-on-failure`

Fixes #82