### PR TITLE
Fixes #78: Implement remaining expression operators

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -59,6 +59,7 @@ unsigned short internalRS;
 }
 
 %token T_COMMA T_OPEN_PAREN T_CLOSE_PAREN T_PLUS T_MINUS T_HASH_OPEN_PAREN
+%token T_PIPE T_AMP T_SHIFT_RIGHT
 %token T_INES_PRG T_INES_CHR T_INES_MIR T_INES_MAP
 %token T_BANK T_ORG
 %token T_DATA_WORD T_DATA_BYTE
@@ -111,6 +112,9 @@ unsigned short internalRS;
 %type <byte> bank_header
 %type <byte> bank_no
 
+%left T_PIPE
+%left T_AMP
+%left T_SHIFT_RIGHT
 %left T_PLUS T_MINUS
 
 %%
@@ -457,6 +461,9 @@ byte_data:
 byte_expr:
   byte_expr T_PLUS byte_value { $$ = $1 + $3; }
   | byte_expr T_MINUS byte_value { $$ = $1 - $3; }
+  | byte_expr T_SHIFT_RIGHT byte_value { $$ = $1 >> $3; }
+  | byte_expr T_AMP byte_value { $$ = $1 & $3; }
+  | byte_expr T_PIPE byte_value { $$ = $1 | $3; }
   | byte_primary
   ;
 
@@ -496,6 +503,9 @@ byte_value:
 byte_value_expr:
   byte_value_expr T_PLUS byte_value { $$ = $1 + $3; }
   | byte_value_expr T_MINUS byte_value { $$ = $1 - $3; }
+  | byte_value_expr T_SHIFT_RIGHT byte_value { $$ = $1 >> $3; }
+  | byte_value_expr T_AMP byte_value { $$ = $1 & $3; }
+  | byte_value_expr T_PIPE byte_value { $$ = $1 | $3; }
   | byte_value
   ;
 
@@ -529,6 +539,9 @@ byte_imm:
 byte_expr_imm:
   byte_expr_imm T_PLUS byte_value_imm { $$ = $1 + $3; }
   | byte_expr_imm T_MINUS byte_value_imm { $$ = $1 - $3; }
+  | byte_expr_imm T_SHIFT_RIGHT byte_value_imm { $$ = $1 >> $3; }
+  | byte_expr_imm T_AMP byte_value_imm { $$ = $1 & $3; }
+  | byte_expr_imm T_PIPE byte_value_imm { $$ = $1 | $3; }
   | byte_primary_imm
   ;
 
@@ -579,6 +592,9 @@ byte_value_imm:
 byte_value_expr_imm:
   byte_value_expr_imm T_PLUS byte_value_imm { $$ = $1 + $3; }
   | byte_value_expr_imm T_MINUS byte_value_imm { $$ = $1 - $3; }
+  | byte_value_expr_imm T_SHIFT_RIGHT byte_value_imm { $$ = $1 >> $3; }
+  | byte_value_expr_imm T_AMP byte_value_imm { $$ = $1 & $3; }
+  | byte_value_expr_imm T_PIPE byte_value_imm { $$ = $1 | $3; }
   | byte_value_imm
   ;
 
@@ -644,6 +660,9 @@ word_imm:
 word_expr:
   word_expr T_PLUS word_value { $$ = $1 + $3; }
   | word_expr T_MINUS word_value { $$ = $1 - $3; }
+  | word_expr T_SHIFT_RIGHT word_value { $$ = $1 >> $3; }
+  | word_expr T_AMP word_value { $$ = $1 & $3; }
+  | word_expr T_PIPE word_value { $$ = $1 | $3; }
   | word_primary
   ;
 
@@ -668,12 +687,18 @@ word_value:
 word_value_expr:
   word_value_expr T_PLUS word_value { $$ = $1 + $3; }
   | word_value_expr T_MINUS word_value { $$ = $1 - $3; }
+  | word_value_expr T_SHIFT_RIGHT word_value { $$ = $1 >> $3; }
+  | word_value_expr T_AMP word_value { $$ = $1 & $3; }
+  | word_value_expr T_PIPE word_value { $$ = $1 | $3; }
   | word_value
   ;
 
 word_expr_imm:
   word_expr_imm T_PLUS word_value_imm { $$ = $1 + $3; }
   | word_expr_imm T_MINUS word_value_imm { $$ = $1 - $3; }
+  | word_expr_imm T_SHIFT_RIGHT word_value_imm { $$ = $1 >> $3; }
+  | word_expr_imm T_AMP word_value_imm { $$ = $1 & $3; }
+  | word_expr_imm T_PIPE word_value_imm { $$ = $1 | $3; }
   | word_primary_imm
   ;
 
@@ -708,6 +733,9 @@ word_value_imm:
 word_value_expr_imm:
   word_value_expr_imm T_PLUS word_value_imm { $$ = $1 + $3; }
   | word_value_expr_imm T_MINUS word_value_imm { $$ = $1 - $3; }
+  | word_value_expr_imm T_SHIFT_RIGHT word_value_imm { $$ = $1 >> $3; }
+  | word_value_expr_imm T_AMP word_value_imm { $$ = $1 & $3; }
+  | word_value_expr_imm T_PIPE word_value_imm { $$ = $1 | $3; }
   | word_value_imm
   ;
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -88,6 +88,9 @@ NAME [a-zA-Z_][a-zA-Z0-9_]*
 [\)\]]                 { return T_CLOSE_PAREN; }
 \+                     { return T_PLUS; }
 \-                     { return T_MINUS; }
+\|                     { return T_PIPE; }
+\&                     { return T_AMP; }
+>>                     { return T_SHIFT_RIGHT; }
 =                      { return T_EQU; }
 
   /* ines header */

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -178,6 +178,46 @@ TEST_CASE("word expressions support add/subtract with parentheses",
   std::remove(output_path.c_str());
 }
 
+TEST_CASE("word expressions support bitwise and shift operators",
+          "[integration][assembly]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_word_bitwise_expr.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_word_bitwise_expr.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n\n";
+    output << ".dw ($f0f0 | $000f), ($f0f0 & $0ff0), ($1234 >> 4)\n";
+    output << "LDA $1234 | $0003 & $12ff\n";
+  }
+
+  const ProcessResult result = run_yana(
+      {"-o", ".yana_test_word_bitwise_expr.nes", ".yana_test_word_bitwise_expr.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 16 + 9);
+  const std::vector<unsigned char> actual(rom.begin() + 16, rom.begin() + 16 + 9);
+  const std::vector<unsigned char> expected = {
+      0xff, 0xf0,        // .dw ($f0f0 | $000f)
+      0xf0, 0x00,        // .dw ($f0f0 & $0ff0)
+      0x23, 0x01,        // .dw ($1234 >> 4)
+      0xad, 0x37, 0x12,  // LDA (($1234 | $0003) & $12ff)
+  };
+
+  REQUIRE(actual == expected);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}
+
 TEST_CASE("invalid addressing mode is rejected", "[integration][negative]") {
   expect_assembler_failure({"-o", ".yana_test_addr_mode.nes", "negative/invalid_addr_mode.asm"});
 }
@@ -221,6 +261,51 @@ TEST_CASE("byte expressions support add/subtract and reject out of range",
       0xa9, 0xfe,  // LDA #($ff - 1)
       0xb1, 0x22,  // LDA ($20 + 2), Y
       0xa1, 0x23,  // LDA ($20 + 3, X)
+  };
+  REQUIRE(actual == expected);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}
+
+TEST_CASE("byte expressions support bitwise and shift operators",
+          "[integration][assembly]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_byte_bitwise_expr.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_byte_bitwise_expr.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n\n";
+    output << ".db ($f0 | $0f), ($f3 & $0f), ($80 >> 3)\n";
+    output << "LDA #$f0 | $01\n";
+    output << "LDA #$f3 & $0f\n";
+    output << "LDA #$80 >> 2\n";
+    output << "LDA ($f0 & $0f), Y\n";
+    output << "LDA ($80 >> 2, X)\n";
+  }
+
+  const ProcessResult result = run_yana(
+      {"-o", ".yana_test_byte_bitwise_expr.nes", ".yana_test_byte_bitwise_expr.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 16 + 13);
+  const std::vector<unsigned char> actual(rom.begin() + 16, rom.begin() + 16 + 13);
+  const std::vector<unsigned char> expected = {
+      0xff, 0x03, 0x10,  // .db ($f0 | $0f), ($f3 & $0f), ($80 >> 3)
+      0xa9, 0xf1,        // LDA #($f0 | $01)
+      0xa9, 0x03,        // LDA #($f3 & $0f)
+      0xa9, 0x20,        // LDA #($80 >> 2)
+      0xb1, 0x00,        // LDA ($f0 & $0f), Y
+      0xa1, 0x20,        // LDA ($80 >> 2, X)
   };
   REQUIRE(actual == expected);
 


### PR DESCRIPTION
## Summary
- add scanner tokens for `|`, `&`, and `>>`
- extend parser expression grammar so these operators work in both word and byte expressions (including immediate forms)
- add Catch2 integration tests that exercise each new operator in word and byte expression paths

## Test plan
- [x] `ctest --test-dir build --output-on-failure`

Fixes #78