### PR TITLE
Add immediate parenthesized expression support

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -58,7 +58,7 @@ unsigned short internalRS;
   struct symbol sym;
 }
 
-%token T_COMMA T_OPEN_PAREN T_CLOSE_PAREN T_PLUS T_MINUS
+%token T_COMMA T_OPEN_PAREN T_CLOSE_PAREN T_PLUS T_MINUS T_HASH_OPEN_PAREN
 %token T_INES_PRG T_INES_CHR T_INES_MIR T_INES_MAP
 %token T_BANK T_ORG
 %token T_DATA_WORD T_DATA_BYTE
@@ -520,7 +520,10 @@ zp_byte:
   ;
 
 byte_imm:
-  byte_expr_imm { $$ = byte_expr_value($1, "Operand out of range"); }
+  T_HASH_OPEN_PAREN byte_value_expr_imm T_CLOSE_PAREN {
+    $$ = byte_expr_value($2, "Operand out of range");
+  }
+  | byte_expr_imm { $$ = byte_expr_value($1, "Operand out of range"); }
   ;
 
 byte_expr_imm:
@@ -559,6 +562,12 @@ byte_primary_imm:
     localSymbols.addForwardLow($3, currentBankNo, currentBank->currentOffset() + 1, line_num);
     logforwardsymbol($3);
     $$ = 0xff;
+  }
+  | T_LOW T_OPEN_PAREN T_SYMBOL T_CLOSE_PAREN {
+    $$ = ($3.address & 0xff);
+  }
+  | T_HIGH T_OPEN_PAREN T_SYMBOL T_CLOSE_PAREN {
+    $$ = ($3.address >> 8);
   }
   | T_OPEN_PAREN byte_value_expr_imm T_CLOSE_PAREN { $$ = $2; }
   ;
@@ -617,7 +626,8 @@ word_data:
   ;
 
 word_imm:
-  word_expr_imm
+  T_HASH_OPEN_PAREN word_value_expr_imm T_CLOSE_PAREN { $$ = $2; }
+  | word_expr_imm
   | T_FORWARD_SYMBOL_IMM {
     // If forward_symbol is caught here, it will always have an instruction before it
     // That's why we add 1 to the currentOffset.

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -195,6 +195,7 @@ X                      { return T_X_REGISTER; }
 Y                      { return T_Y_REGISTER; }
 A                      { return T_ACCUMULATOR; }
 
+"#\("                  { return T_HASH_OPEN_PAREN; }
 #\$[a-fA-F0-9]{1,4}    {
   /* Hex immediate value */
   unsigned short val = strtol(yytext + 2, 0, 16);

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -252,6 +252,44 @@ TEST_CASE("byte expression out of range is rejected", "[integration][negative]")
   std::remove((std::string(YANA_DATA_DIR) + "/.yana_test_byte_expr_range.nes").c_str());
 }
 
+TEST_CASE("immediate parenthesized expressions are supported",
+          "[integration][assembly]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_immediate_expr.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_immediate_expr.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n\n";
+    output << "base = $1234\n";
+    output << "LDA #($10 + 1)\n";
+    output << "LDA #(LOW(base) + 1)\n";
+  }
+
+  const ProcessResult result = run_yana(
+      {"-o", ".yana_test_immediate_expr.nes", ".yana_test_immediate_expr.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 16 + 4);
+  const std::vector<unsigned char> actual(rom.begin() + 16, rom.begin() + 16 + 4);
+  const std::vector<unsigned char> expected = {
+      0xa9, 0x11,  // LDA #($10 + 1)
+      0xa9, 0x35,  // LDA #(LOW($1234) + 1)
+  };
+  REQUIRE(actual == expected);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}
+
 TEST_CASE("forward symbols work inside word/byte data expressions",
           "[integration][assembly]") {
   const std::string asm_path =


### PR DESCRIPTION
## Summary

- Support `#(...)` immediate operands with arithmetic and `LOW`/`HIGH` forms
- Wire immediate expression parsing into `byte_imm` and `word_imm`
- Add Catch2 integration coverage

## Dependencies

Stacks on open expression PRs #96 and #97 (and merged #95).

## Test plan

- [x] `ctest --test-dir build --output-on-failure` (17/17 passed locally)

Fixes #90