### PR TITLE
Fixes #54: JMP indirect (C) vs absolute (C)

### DIFF
--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -48,7 +48,7 @@ int opcode_CC01_set_addr_mode(unsigned char base, unsigned char addr_mode, unsig
   110 absolute,Y
   111 absolute,X
    */
-  if (addr_mode == mode_ACC) {
+  if (addr_mode == mode_ACC || addr_mode == mode_IND) {
     return 0;
   }
 
@@ -92,6 +92,7 @@ int opcode_CC10_set_addr_mode(unsigned char base, unsigned char addr_mode, unsig
 
     case mode_IND_X:
     case mode_IND_Y:
+    case mode_IND:
     case mode_ABS_Y:
     default:
       return 0;
@@ -109,7 +110,7 @@ static int cc00_addr_mode_valid(unsigned char base, unsigned char addr_mode) {
       return addr_mode == mode_ZERO || addr_mode == mode_ABS;
 
     case 2: /* JMP */
-      return addr_mode == mode_ABS;
+      return addr_mode == mode_ABS || addr_mode == mode_IND;
 
     case 4: /* STY */
       return addr_mode == mode_ZERO || addr_mode == mode_ABS ||
@@ -132,6 +133,12 @@ static int cc00_addr_mode_valid(unsigned char base, unsigned char addr_mode) {
 int opcode_CC00_set_addr_mode(unsigned char base, unsigned char addr_mode, unsigned char *out) {
   if (!cc00_addr_mode_valid(base, addr_mode)) {
     return 0;
+  }
+
+  unsigned char aaa = (base >> 5) & 0x7;
+  if (aaa == 2 && addr_mode == mode_IND) {
+    *out = 0x6c;
+    return 1;
   }
 
   return opcode_CC10_set_addr_mode(base, addr_mode, out);

--- a/src/opcodes.h
+++ b/src/opcodes.h
@@ -31,6 +31,7 @@
 #define mode_ABS_Y  0x06
 #define mode_ABS_X  0x07
 #define mode_ACC    0x08
+#define mode_IND    0x09
 
 int opcode_set_addr_mode(unsigned char group, unsigned char base, unsigned char addr_mode,
                          unsigned char *out);

--- a/src/parser.y
+++ b/src/parser.y
@@ -307,6 +307,15 @@ instruction:
     logoptype("ABS_Y", $1.base);
     loginstr($2);
   }
+  | T_INSTR T_OPEN_PAREN word T_CLOSE_PAREN {
+    ENCODE_ADDR_MODE($1, mode_IND);
+
+    currentBank->addByte($1.base);
+    currentBank->addWord($3);
+
+    logoptype("IND", $1.base);
+    loginstr($3);
+  }
   | T_INSTR T_OPEN_PAREN zp_byte T_CLOSE_PAREN T_COMMA T_Y_REGISTER {
     ENCODE_ADDR_MODE($1, mode_IND_Y);
 
@@ -524,7 +533,7 @@ byte_value_expr:
 
 zp_byte:
   byte
-  | word_expr {
+  | byte_value_expr {
     $$ = byte_expr_value($1, "Indirect addressing requires a zero page operand");
   }
   | T_SYMBOL {

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -375,6 +375,43 @@ TEST_CASE("immediate parenthesized expressions are supported",
   std::remove(output_path.c_str());
 }
 
+TEST_CASE("jmp absolute and indirect encode distinct opcodes",
+          "[integration][assembly]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_jmp_modes.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_jmp_modes.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n\n";
+    output << "JMP $8000\n";
+    output << "JMP ($FFFC)\n";
+  }
+
+  const ProcessResult result =
+      run_yana({"-o", ".yana_test_jmp_modes.nes", ".yana_test_jmp_modes.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 16 + 6);
+  const std::vector<unsigned char> actual(rom.begin() + 16, rom.begin() + 16 + 6);
+  const std::vector<unsigned char> expected = {
+      0x4c, 0x00, 0x80,  // JMP $8000
+      0x6c, 0xfc, 0xff,  // JMP ($FFFC)
+  };
+  REQUIRE(actual == expected);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}
+
 TEST_CASE("forward symbols work inside word/byte data expressions",
           "[integration][assembly]") {
   const std::string asm_path =


### PR DESCRIPTION
## Summary
- add `mode_IND` as a distinct addressing mode for `JMP ($addr)`
- update opcode encoding so CC00/JMP accepts both absolute (`$4C`) and indirect (`$6C`) forms
- extend parser + integration tests to validate `JMP $8000` => `4C 00 80` and `JMP ($FFFC)` => `6C FC FF`

## Test plan
- [x] `cmake --build build && ctest --test-dir build --output-on-failure`

Fixes #54