### PR TITLE
Fixes #40: Add .inesflags7 directive

### DIFF
--- a/src/ines_header.h
+++ b/src/ines_header.h
@@ -61,6 +61,11 @@ public:
     updateFlags7();
   };
 
+  void setFlags7(unsigned char value) {
+    flags7 = value;
+    updateFlags7();
+  };
+
   unsigned char mapper() {
     unsigned char lower = (flags6 >> 4);
     unsigned char upper = (flags7 >> 4);

--- a/src/parser.y
+++ b/src/parser.y
@@ -61,7 +61,7 @@ unsigned short internalRS;
 
 %token T_COMMA T_OPEN_PAREN T_CLOSE_PAREN T_PLUS T_MINUS T_HASH_OPEN_PAREN
 %token T_PIPE T_AMP T_SHIFT_RIGHT T_LT T_GT T_LE T_GE T_NE
-%token T_INES_PRG T_INES_CHR T_INES_MIR T_INES_MAP
+%token T_INES_PRG T_INES_CHR T_INES_MIR T_INES_MAP T_INES_FLAGS7
 %token T_BANK T_ORG
 %token T_DATA_WORD T_DATA_BYTE
 %token T_X_REGISTER T_Y_REGISTER T_ACCUMULATOR
@@ -149,6 +149,9 @@ ines_entry:
   }
   | T_INES_MAP byte {
     inesHeader.setMapper($2);
+  }
+  | T_INES_FLAGS7 byte {
+    inesHeader.setFlags7($2);
   }
   ;
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -103,6 +103,7 @@ NAME [a-zA-Z_][a-zA-Z0-9_]*
 \.ineschr              { return T_INES_CHR; }
 \.inesmir              { return T_INES_MIR; }
 \.inesmap              { return T_INES_MAP; }
+\.inesflags7           { return T_INES_FLAGS7; }
 
   /* bank handling */
 \.bank                 { return T_BANK; }

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -488,3 +488,34 @@ TEST_CASE("comparison operators evaluate to 0 or 1 in expressions",
   std::remove(asm_path.c_str());
   std::remove(output_path.c_str());
 }
+
+TEST_CASE("inesflags7 directive sets iNES header byte 7", "[integration][assembly]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_ines_flags7.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_ines_flags7.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n";
+    output << ".inesflags7 $AB\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n";
+    output << "NOP\n";
+  }
+
+  const ProcessResult result = run_yana(
+      {"-o", ".yana_test_ines_flags7.nes", ".yana_test_ines_flags7.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 17);
+  REQUIRE(static_cast<unsigned char>(rom[7]) == 0xAB);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}


### PR DESCRIPTION
## Summary

- Add `InesHeader::setFlags7()` to write iNES header byte 7 directly
- Add `.inesflags7` scanner/parser directive
- Catch2 test verifies ROM byte 7 after assembly

## Test plan

- [x] `cmake --build build`
- [x] `ctest --test-dir build --output-on-failure` (23/23)

Fixes #40