### PR TITLE
Fixes #41: Add .inesflags9 and .inesflags10 directives

### DIFF
--- a/src/ines_header.h
+++ b/src/ines_header.h
@@ -66,6 +66,16 @@ public:
     updateFlags7();
   };
 
+  void setFlags9(unsigned char value) {
+    flags9 = value;
+    updateFlags9();
+  };
+
+  void setFlags10(unsigned char value) {
+    flags10 = value;
+    updateFlags10();
+  };
+
   unsigned char mapper() {
     unsigned char lower = (flags6 >> 4);
     unsigned char upper = (flags7 >> 4);

--- a/src/parser.y
+++ b/src/parser.y
@@ -61,7 +61,7 @@ unsigned short internalRS;
 
 %token T_COMMA T_OPEN_PAREN T_CLOSE_PAREN T_PLUS T_MINUS T_HASH_OPEN_PAREN
 %token T_PIPE T_AMP T_SHIFT_RIGHT T_LT T_GT T_LE T_GE T_NE
-%token T_INES_PRG T_INES_CHR T_INES_MIR T_INES_MAP T_INES_FLAGS7
+%token T_INES_PRG T_INES_CHR T_INES_MIR T_INES_MAP T_INES_FLAGS7 T_INES_FLAGS9 T_INES_FLAGS10
 %token T_BANK T_ORG
 %token T_DATA_WORD T_DATA_BYTE
 %token T_X_REGISTER T_Y_REGISTER T_ACCUMULATOR
@@ -152,6 +152,12 @@ ines_entry:
   }
   | T_INES_FLAGS7 byte {
     inesHeader.setFlags7($2);
+  }
+  | T_INES_FLAGS9 byte {
+    inesHeader.setFlags9($2);
+  }
+  | T_INES_FLAGS10 byte {
+    inesHeader.setFlags10($2);
   }
   ;
 

--- a/src/scanner.l
+++ b/src/scanner.l
@@ -104,6 +104,8 @@ NAME [a-zA-Z_][a-zA-Z0-9_]*
 \.inesmir              { return T_INES_MIR; }
 \.inesmap              { return T_INES_MAP; }
 \.inesflags7           { return T_INES_FLAGS7; }
+\.inesflags9           { return T_INES_FLAGS9; }
+\.inesflags10          { return T_INES_FLAGS10; }
 
   /* bank handling */
 \.bank                 { return T_BANK; }

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -519,3 +519,37 @@ TEST_CASE("inesflags7 directive sets iNES header byte 7", "[integration][assembl
   std::remove(asm_path.c_str());
   std::remove(output_path.c_str());
 }
+
+TEST_CASE("inesflags9 and inesflags10 directives set NES 2.0 header bytes",
+          "[integration][assembly]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_ines_flags9_10.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_ines_flags9_10.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 0\n";
+    output << ".inesmir 1\n";
+    output << ".inesflags9 $12\n";
+    output << ".inesflags10 $34\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n";
+    output << "NOP\n";
+  }
+
+  const ProcessResult result = run_yana(
+      {"-o", ".yana_test_ines_flags9_10.nes", ".yana_test_ines_flags9_10.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() >= 17);
+  REQUIRE(static_cast<unsigned char>(rom[9]) == 0x12);
+  REQUIRE(static_cast<unsigned char>(rom[10]) == 0x34);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}


### PR DESCRIPTION
## Summary

- Add `setFlags9()` / `setFlags10()` on `InesHeader`
- Add `.inesflags9` and `.inesflags10` parser directives
- Catch2 test verifies ROM header bytes 9 and 10

## Test plan

- [x] `ctest --test-dir build --output-on-failure` (24/24)

Fixes #41