### PR TITLE
Fixes #17: Add mapper 2 (UNROM) support

### DIFF
--- a/src/parser.y
+++ b/src/parser.y
@@ -121,6 +121,10 @@ unsigned short internalRS;
 %%
 program:
   ines_header banks {
+    if (inesHeader.mapper() == 2 && inesHeader.prgRomSize() < 2) {
+      yyerror("Mapper 2 requires at least 2 PRG banks");
+      YYABORT;
+    }
     if (!bankTable.updateForwardSymbols(localSymbols)) {
       yyerror("Failed to update forward symbols.");
       YYABORT;
@@ -148,6 +152,10 @@ ines_entry:
     inesHeader.setMirroringNESASM($2);
   }
   | T_INES_MAP byte {
+    if ($2 != 0 && $2 != 2) {
+      yyerror("Unsupported mapper");
+      YYABORT;
+    }
     inesHeader.setMapper($2);
   }
   | T_INES_FLAGS7 byte {
@@ -184,6 +192,8 @@ bank_header:
     bank_type type = PRG;
     if ($1 >= inesHeader.prgRomSize()) {
       type = CHR;
+    } else if (inesHeader.mapper() == 2) {
+      type = PRG16;
     }
 
     currentBankNo = $1;
@@ -196,6 +206,8 @@ bank_header:
     bank_type type = PRG;
     if ($2 >= inesHeader.prgRomSize()) {
       type = CHR;
+    } else if (inesHeader.mapper() == 2) {
+      type = PRG16;
     }
 
     currentBankNo = $2;

--- a/tests/integration_tests.cpp
+++ b/tests/integration_tests.cpp
@@ -587,3 +587,78 @@ TEST_CASE("inestrainer directive writes 512-byte trainer section after header",
   std::remove(asm_path.c_str());
   std::remove(output_path.c_str());
 }
+
+TEST_CASE("mapper 2 uses 16KB PRG banks and validates bank count",
+          "[integration][assembly][negative]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_mapper2.asm";
+  const std::string output_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_mapper2.nes";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 2\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 2\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n";
+    output << ".db $AA\n";
+    output << ".bank 1\n";
+    output << ".org $C000\n";
+    output << ".db $BB\n";
+  }
+
+  const ProcessResult result =
+      run_yana({"-o", ".yana_test_mapper2.nes", ".yana_test_mapper2.asm"});
+  REQUIRE(result.exit_code == 0);
+
+  const std::string rom = read_file(output_path);
+  REQUIRE(rom.size() == 16 + 16384 + 16384);
+  REQUIRE(static_cast<unsigned char>(rom[16]) == 0xAA);
+  REQUIRE(static_cast<unsigned char>(rom[16 + 16384]) == 0xBB);
+
+  std::remove(asm_path.c_str());
+  std::remove(output_path.c_str());
+}
+
+TEST_CASE("unsupported mapper is rejected", "[integration][negative]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_bad_mapper.asm";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 3\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n";
+    output << "NOP\n";
+  }
+
+  expect_assembler_failure({"-o", ".yana_test_bad_mapper.nes", ".yana_test_bad_mapper.asm"});
+  std::remove(asm_path.c_str());
+}
+
+TEST_CASE("mapper 2 with insufficient PRG banks is rejected", "[integration][negative]") {
+  const std::string asm_path =
+      std::string(YANA_DATA_DIR) + "/.yana_test_mapper2_prg.asm";
+
+  {
+    std::ofstream output(asm_path);
+    REQUIRE(output.is_open());
+    output << ".inesprg 1\n";
+    output << ".ineschr 0\n";
+    output << ".inesmap 2\n";
+    output << ".inesmir 1\n\n";
+    output << ".bank 0\n";
+    output << ".org $8000\n";
+    output << "NOP\n";
+  }
+
+  expect_assembler_failure({"-o", ".yana_test_mapper2_prg.nes", ".yana_test_mapper2_prg.asm"});
+  std::remove(asm_path.c_str());
+}


### PR DESCRIPTION
## Summary

- Validate mapper support (mapper 0 and 2 only for now)
- Mapper 2 requires at least 2 PRG banks and uses 16KB `PRG16` bank objects
- Reject unsupported mappers and insufficient PRG bank counts with clear errors
- Integration tests for UNROM ROM layout (32KB PRG) and negative cases

## Test plan

- [x] `ctest --test-dir build --output-on-failure` (28/28)

Fixes #17